### PR TITLE
feat: プロジェクト名を変更可能にする (Issue #30)

### DIFF
--- a/components/editor/TopBar.tsx
+++ b/components/editor/TopBar.tsx
@@ -12,6 +12,12 @@ const TopBar = () => {
     const { undo, redo, pastStates, futureStates } = useZustandStore(useStore.temporal, (state) => state);
 
     const [addCount, setAddCount] = React.useState(1);
+    const [localName, setLocalName] = React.useState(project.name);
+
+    // Sync local state when project.name changes externally (e.g. undo/redo)
+    React.useEffect(() => {
+        setLocalName(project.name);
+    }, [project.name]);
 
     const handleAddKey = () => {
         addKeys(addCount, {
@@ -80,8 +86,19 @@ const TopBar = () => {
                 </h1>
                 <input
                     type="text"
-                    value={project.name}
-                    onChange={(e) => setProjectName(e.target.value)}
+                    value={localName}
+                    onChange={(e) => setLocalName(e.target.value)}
+                    onBlur={() => {
+                        if (localName.trim() !== project.name) {
+                            setProjectName(localName.trim() || 'Untitled Project');
+                        }
+                    }}
+                    onKeyDown={(e) => {
+                        e.stopPropagation();
+                        if (e.key === 'Enter') {
+                            e.currentTarget.blur();
+                        }
+                    }}
                     className="bg-transparent text-gray-300 text-sm focus:outline-none focus:border-b border-gray-500 hover:text-white transition-colors w-48"
                     placeholder="Project Name"
                 />


### PR DESCRIPTION
GitHub Issue #30 に対応しました。
## 変更内容
TopBar のプロジェクト名表示を span から input に変更し、ユーザーがプロジェクト名を編集できるようにしました。

## 対応するIssue
Closes #30