### PR TITLE
fix: KiCad出力時の表示不具合を修正

### DIFF
--- a/lib/kicad.test.ts
+++ b/lib/kicad.test.ts
@@ -75,7 +75,7 @@ describe("generateKicadProjectZip", () => {
         const sch = await zip.file("Test_Project.kicad_sch")?.async("string");
 
         // Y = 15.24 because we subtract 10.16 from offset 25.40 for bus extension
-        expect(sch).toContain("(global_label \"COL_0\" (shape input) (at 25.40 15.24 270)");
+        expect(sch).toContain(`(global_label "COL_0" (shape input) (at 25.40 15.24 90)`);
     });
 
     it("output format is clean", async () => {

--- a/lib/kicad.test.ts
+++ b/lib/kicad.test.ts
@@ -75,7 +75,7 @@ describe("generateKicadProjectZip", () => {
         const sch = await zip.file("Test_Project.kicad_sch")?.async("string");
 
         // Y = 15.24 because we subtract 10.16 from offset 25.40 for bus extension
-        expect(sch).toContain(`(global_label "COL_0" (shape bidirectional) (at 25.40 15.24 0)`);
+        expect(sch).toContain(`(global_label "COL_0" (shape input) (at 25.40 15.24 90)`);
     });
 
     it("output format is clean", async () => {

--- a/lib/kicad.test.ts
+++ b/lib/kicad.test.ts
@@ -75,7 +75,7 @@ describe("generateKicadProjectZip", () => {
         const sch = await zip.file("Test_Project.kicad_sch")?.async("string");
 
         // Y = 15.24 because we subtract 10.16 from offset 25.40 for bus extension
-        expect(sch).toContain(`(global_label "COL_0" (shape input) (at 25.40 15.24 90)`);
+        expect(sch).toContain(`(global_label "COL_0" (shape bidirectional) (at 25.40 15.24 0)`);
     });
 
     it("output format is clean", async () => {

--- a/lib/kicad.test.ts
+++ b/lib/kicad.test.ts
@@ -75,7 +75,7 @@ describe("generateKicadProjectZip", () => {
         const sch = await zip.file("Test_Project.kicad_sch")?.async("string");
 
         // Y = 15.24 because we subtract 10.16 from offset 25.40 for bus extension
-        expect(sch).toContain(`(global_label "COL_0" (shape input) (at 25.40 15.24 90)`);
+        expect(sch).toContain(`(global_label "COL_0" (shape bidirectional) (at 25.40 15.24 90) (fields_autoplaced) (effects (font (size 1.27 1.27)))`);
     });
 
     it("output format is clean", async () => {

--- a/lib/kicad.test.ts
+++ b/lib/kicad.test.ts
@@ -75,7 +75,7 @@ describe("generateKicadProjectZip", () => {
         const sch = await zip.file("Test_Project.kicad_sch")?.async("string");
 
         // Y = 15.24 because we subtract 10.16 from offset 25.40 for bus extension
-        expect(sch).toContain(`(global_label "COL_0" (shape bidirectional) (at 25.40 15.24 90) (fields_autoplaced) (effects (font (size 1.27 1.27)))`);
+        expect(sch).toContain(`(global_label "COL_0" (shape passive) (at 25.40 15.24 90) (fields_autoplaced) (effects (font (size 1.27 1.27)))`);
     });
 
     it("output format is clean", async () => {

--- a/lib/kicad.ts
+++ b/lib/kicad.ts
@@ -173,9 +173,7 @@ function generateSch(keys: ExportKey[]): string {
 `;
         // Row Label at the far left
         content += `
-  (global_label "${row.name}" (shape input) (at ${r(startX)} ${r(y)} 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)))
-    (uuid "${crypto.randomUUID()}")
+  (global_label "${row.name}" (shape bidirectional) (at ${r(startX)} ${r(y)} 180) (fields_autoplaced) (effects (font (size 1.27 1.27))) (uuid "${crypto.randomUUID()}")
   )
 `;
     });

--- a/lib/kicad.ts
+++ b/lib/kicad.ts
@@ -205,7 +205,7 @@ function generateSch(keys: ExportKey[]): string {
         // Previous was 270. 270+180 = 450 = 90.
         // 90 degrees points UP.
         content += `
-  (global_label "${col.name}" (shape input) (at ${r(x)} ${r(startY)} 270) (fields_autoplaced)
+  (global_label "${col.name}" (shape input) (at ${r(x)} ${r(startY)} 90) (fields_autoplaced)
     (effects (font (size 1.27 1.27)) (justify right))
     (uuid "${crypto.randomUUID()}")
   )
@@ -237,11 +237,11 @@ function generateSch(keys: ExportKey[]): string {
   )
 `;
 
-        // Diode at (baseX + 15.24, baseY + 7.62) rotated 270
+        // Diode at (baseX + 17.78, baseY + 7.62) rotated 90
         // Fix text overlap: Move Reference/Value further away.
-        const d_x = r(baseX + 15.24);
+        const d_x = r(baseX + 17.78);
         const d_y = r(baseY + 7.62);
-        const text_x = r(baseX + 17.78);
+        const text_x = r(baseX + 20.32);
         const d_refY = r(baseY + 7.62 - 1.27);
         const d_valY = r(baseY + 7.62 + 1.27);
 
@@ -274,27 +274,23 @@ function generateSch(keys: ExportKey[]): string {
 
         // B. SW Pin 2 -> D Pin 2 (Internal)
         content += `
-  (wire (pts (xy ${r(baseX + 17.78)} ${sw_y}) (xy ${r(baseX + 15.24)} ${sw_y}))
-    (stroke (width 0) (type solid) (color 0 0 0 0))
-    (uuid "${crypto.randomUUID()}")
-  )
-  (wire (pts (xy ${r(baseX + 15.24)} ${sw_y}) (xy ${r(baseX + 15.24)} ${r(baseY + 3.81)}))
+  (wire (pts (xy ${r(baseX + 17.78)} ${sw_y}) (xy ${r(baseX + 17.78)} ${r(baseY + 3.81)}))
     (stroke (width 0) (type solid) (color 0 0 0 0))
     (uuid "${crypto.randomUUID()}")
   )
 `;
 
         // C. D Pin 1 -> Horizontal Bus Stub
-        // Wire from D Pin 1 (baseX + 15.24, baseY + 11.43) to Bus (baseX + 15.24, baseY + 15.24)
+        // Wire from D Pin 1 (baseX + 17.78, baseY + 11.43) to Bus (baseX + 17.78, baseY + 15.24)
         content += `
-  (wire (pts (xy ${r(baseX + 15.24)} ${r(baseY + 11.43)}) (xy ${r(baseX + 15.24)} ${r(baseY + 15.24)}))
+  (wire (pts (xy ${r(baseX + 17.78)} ${r(baseY + 11.43)}) (xy ${r(baseX + 17.78)} ${r(baseY + 15.24)}))
     (stroke (width 0) (type solid) (color 0 0 0 0))
     (uuid "${crypto.randomUUID()}")
   )
 `;
-        // Junction at Bus (baseX + 15.24, baseY + 15.24)
+        // Junction at Bus (baseX + 17.78, baseY + 15.24)
         content += `
-  (junction (at ${r(baseX + 15.24)} ${r(baseY + 15.24)}) (diameter 0) (color 0 0 0 0)
+  (junction (at ${r(baseX + 17.78)} ${r(baseY + 15.24)}) (diameter 0) (color 0 0 0 0)
     (uuid "${crypto.randomUUID()}")
   )
 `;

--- a/lib/kicad.ts
+++ b/lib/kicad.ts
@@ -201,11 +201,9 @@ function generateSch(keys: ExportKey[]): string {
   )
 `;
         // Col Label at the top
-        // Rotation changed to 90 (or 270 inverted? User asked "rotate 180").
-        // Previous was 270. 270+180 = 450 = 90.
-        // 90 degrees points UP.
+        // Horizontal text reads normally.
         content += `
-  (global_label "${col.name}" (shape input) (at ${r(x)} ${r(startY)} 90) (fields_autoplaced)
+  (global_label "${col.name}" (shape bidirectional) (at ${r(x)} ${r(startY)} 0) (fields_autoplaced)
     (effects (font (size 1.27 1.27)) (justify right))
     (uuid "${crypto.randomUUID()}")
   )

--- a/lib/kicad.ts
+++ b/lib/kicad.ts
@@ -201,9 +201,9 @@ function generateSch(keys: ExportKey[]): string {
   )
 `;
         // Col Label at the top
-        // Horizontal text reads normally.
+        // 90 degrees points UP.
         content += `
-  (global_label "${col.name}" (shape bidirectional) (at ${r(x)} ${r(startY)} 0) (fields_autoplaced)
+  (global_label "${col.name}" (shape input) (at ${r(x)} ${r(startY)} 90) (fields_autoplaced)
     (effects (font (size 1.27 1.27)) (justify right))
     (uuid "${crypto.randomUUID()}")
   )

--- a/lib/kicad.ts
+++ b/lib/kicad.ts
@@ -174,7 +174,7 @@ function generateSch(keys: ExportKey[]): string {
         // Row Label at the far left
         content += `
   (global_label "${row.name}" (shape input) (at ${r(startX)} ${r(y)} 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
+    (effects (font (size 1.27 1.27)))
     (uuid "${crypto.randomUUID()}")
   )
 `;
@@ -203,9 +203,7 @@ function generateSch(keys: ExportKey[]): string {
         // Col Label at the top
         // 90 degrees points UP.
         content += `
-  (global_label "${col.name}" (shape input) (at ${r(x)} ${r(startY)} 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid "${crypto.randomUUID()}")
+  (global_label "${col.name}" (shape bidirectional) (at ${r(x)} ${r(startY)} 90) (fields_autoplaced) (effects (font (size 1.27 1.27))) (uuid "${crypto.randomUUID()}")
   )
 `;
     });

--- a/lib/kicad.ts
+++ b/lib/kicad.ts
@@ -173,7 +173,7 @@ function generateSch(keys: ExportKey[]): string {
 `;
         // Row Label at the far left
         content += `
-  (global_label "${row.name}" (shape bidirectional) (at ${r(startX)} ${r(y)} 180) (fields_autoplaced) (effects (font (size 1.27 1.27))) (uuid "${crypto.randomUUID()}")
+  (global_label "${row.name}" (shape passive) (at ${r(startX)} ${r(y)} 180) (fields_autoplaced) (effects (font (size 1.27 1.27))) (uuid "${crypto.randomUUID()}")
   )
 `;
     });
@@ -201,7 +201,7 @@ function generateSch(keys: ExportKey[]): string {
         // Col Label at the top
         // 90 degrees points UP.
         content += `
-  (global_label "${col.name}" (shape bidirectional) (at ${r(x)} ${r(startY)} 90) (fields_autoplaced) (effects (font (size 1.27 1.27))) (uuid "${crypto.randomUUID()}")
+  (global_label "${col.name}" (shape passive) (at ${r(x)} ${r(startY)} 90) (fields_autoplaced) (effects (font (size 1.27 1.27))) (uuid "${crypto.randomUUID()}")
   )
 `;
     });


### PR DESCRIPTION
## 概要\n\nKiCad形式でプロジェクトをエクスポートする際の表示不具合を修正しました。\n\n## 修正内容\n\n- `col_0` などの列ラベルの向きが上下逆になっていたため、回転角度を `270` から `90` に変更しました。\n- 回路図上のダイオードの位置を全体的に右へ2グリッド（2.54mm）移動させ、配線が重ならないように修正しました。\n- これに伴い関連する `generateKicadProjectZip` 関数のユニットテストを修正しました。