### PR TITLE
⚡ Bolt: [RightSidebar rendering and deletion optimization]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 2. Store the pending state changes in a `useRef`.
 3. Commit the final state to the store only on `dragEnd`.
 This pattern decouples the visual loop from the React render loop.
+
+## 2024-05-18 - RightSidebar Zustand Subscription Opt
+**Learning:** Subscribing to an entire store object via `useStore()` in a globally rendered component like `RightSidebar` will cause it to re-render constantly for unrelated changes (like drag pan/zoom).
+**Action:** Use `useShallow` with a selector mapping to explicitly define dependencies (e.g., `projectKeys` and `selectedKeyIds`). Also, favor bulk array operations like `deleteSelectedKeys()` over $O(N)$ sequential mutations like `forEach(removeKey)` which cause redundant layout reflows and Store updates.

--- a/components/editor/RightSidebar.tsx
+++ b/components/editor/RightSidebar.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useStore } from '@/store/useStore';
+import { useShallow } from 'zustand/react/shallow';
 import { Trash2, Copy, Grid } from 'lucide-react';
 import { KeyVariant } from '@/types/mkd';
 
@@ -42,13 +43,20 @@ const MatrixStartInput: React.FC<MatrixStartInputProps> = ({ row, onRowChange, c
 );
 
 const RightSidebar = () => {
-    const { project, selectedKeyIds, updateKey, removeKey, duplicateSelectedKeys, autoAssignMatrix } = useStore();
+    const { projectKeys, selectedKeyIds, updateKey, deleteSelectedKeys, duplicateSelectedKeys, autoAssignMatrix } = useStore(useShallow(state => ({
+        projectKeys: state.project.keys,
+        selectedKeyIds: state.selectedKeyIds,
+        updateKey: state.updateKey,
+        deleteSelectedKeys: state.deleteSelectedKeys,
+        duplicateSelectedKeys: state.duplicateSelectedKeys,
+        autoAssignMatrix: state.autoAssignMatrix,
+    })));
 
     const [startRow, setStartRow] = React.useState(0);
     const [startCol, setStartCol] = React.useState(0);
 
     const selectedKeySet = React.useMemo(() => new Set(selectedKeyIds), [selectedKeyIds]);
-    const selectedKeys = React.useMemo(() => project.keys.filter((k) => selectedKeySet.has(k.id)), [project.keys, selectedKeySet]);
+    const selectedKeys = React.useMemo(() => projectKeys.filter((k) => selectedKeySet.has(k.id)), [projectKeys, selectedKeySet]);
     const hasSelection = selectedKeys.length > 0;
     const singleSelection = selectedKeys.length === 1;
     const primaryKey = selectedKeys[0];
@@ -105,7 +113,7 @@ const RightSidebar = () => {
             const direction = e.shiftKey ? -1 : 1;
 
             // Sort keys by position (Y then X) to determine visual order
-            const sortedKeys = [...project.keys].sort((a, b) => {
+            const sortedKeys = [...projectKeys].sort((a, b) => {
                 const yDiff = a.position.y - b.position.y;
                 if (Math.abs(yDiff) > 0.01) return yDiff; // Use epsilon for potential float inaccuracies
                 return a.position.x - b.position.x;
@@ -130,7 +138,8 @@ const RightSidebar = () => {
     };
 
     const handleDelete = () => {
-        selectedKeyIds.forEach((id) => removeKey(id));
+        // Optimization: Use the bulk delete action to avoid O(N) Zustand state updates.
+        deleteSelectedKeys();
     };
 
     const handleDuplicate = () => {


### PR DESCRIPTION
**💡 What:**
- Subscribed to a subset of `useStore` properties via `useShallow` selector.
- Replaced the $O(N)$ loop over `removeKey` with a single $O(1)$ batch update call `deleteSelectedKeys()`.

**🎯 Why:**
- Without `useShallow`, `RightSidebar` was needlessly subscribing to the entire application state (e.g. pan and scale), causing redundant layout recalculations/re-renders on high-frequency drag actions.
- `removeKey` creates a distinct store mutation each time it is called. Deleting $N$ keys individually performs $N$ store updates, triggering cascading renders across all observers $N$ times. Calling `deleteSelectedKeys()` processes all of the deletions in one optimized $O(N)$ filter operation internally, dispatching exactly *one* state update overall.

**📊 Impact:**
- Reduced React update cycles on pan/zoom actions inside `RightSidebar`.
- Deletions are now significantly faster and more performant for selections >1 item.

**🔬 Measurement:**
- Verify with unit tests (`pnpm test` passes).
- Try dragging selection bounds, the sidebar should not flicker or lag during map drag.

---
*PR created automatically by Jules for task [16945518314454290142](https://jules.google.com/task/16945518314454290142) started by @ka-zuu*